### PR TITLE
M: fix api call without custom proxy

### DIFF
--- a/src/api/openai.py
+++ b/src/api/openai.py
@@ -184,6 +184,8 @@ class APIRequest:
         """Calls the OpenAI API and saves results."""
         logging.info(f"Starting request #{self.task_id}")
         error = None
+        if proxy == "None":
+            proxy = None
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(


### PR DESCRIPTION
When the command line argument 'proxy' is not specified, it appears as the str type 'None' in the call_API function, causing an error in aiohttp.